### PR TITLE
absURL-eat-anchor-links

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -34,7 +34,7 @@
           </div>
           {{ with .Params.button }}
           {{ if .enable }}
-          <a class="hireMe" href="{{ .link | absURL}}">{{ .label }}</a>
+          <a class="hireMe" href="{{ .link | relURL}}">{{ .label }}</a>
           {{ end }}
           {{ end }}
         </div>


### PR DESCRIPTION
Looks like it is (known problem)[https://discourse.gohugo.io/t/absurl-function-seems-to-eat-html-anchor-links/19833?u=dckq6]

*Solution:*
Changed to relURL